### PR TITLE
Drop rbx, add 2.2, ruby-head/jruby-head, allow failures *head.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,13 @@
 language: ruby
 rvm:
-  - "1.9.3"
-  - "2.0"
-  - "2.1"
-  - jruby-19mode # JRuby in 1.9 mode
-  - rbx-2
+- "1.9.3"
+- "2.0"
+- "2.1"
+- "2.2"
+- ruby-head
+- jruby-head
+matrix:
+  allow_failures:
+  - rvm: ruby-head
+  - rvm: jruby-head
+  fast_finish: true


### PR DESCRIPTION
If required rubies fail tests, skip remaining tests via fast_finish.

cc @Fryguy 